### PR TITLE
Enable the display of main products in the category listing

### DIFF
--- a/src/Resources/views/storefront/component/product/card/group/box-card-group-input.html.twig
+++ b/src/Resources/views/storefront/component/product/card/group/box-card-group-input.html.twig
@@ -44,7 +44,7 @@
                                    value="{{ option.id }}"
                                    class="sas-product-configurator-option-input{% if isCombinableCls %} {{ isCombinableCls }}{% endif %}"
                                    title="{{ optionIdentifier }}"
-                                   data-url="{{ url('sas.frontend.variant.switch', {'productId': product.parentId}) }}"
+                                   data-url="{{ url('sas.frontend.variant.switch', {'productId': product.parentId ?? product.id}) }}"
                                    id="{{ optionIdentifier }}"
                                    {% if isActive %}checked="checked"{% endif %}>
 

--- a/src/Resources/views/storefront/component/product/card/group/box-card-group-select.html.twig
+++ b/src/Resources/views/storefront/component/product/card/group/box-card-group-select.html.twig
@@ -6,7 +6,7 @@
             {% endblock %}
         </label>
         {% block component_product_box_configurator_select %}
-            <select data-name="{{ group.id }}" data-url="{{ url('sas.frontend.variant.switch', {'productId': product.parentId}) }}" name="{{ groupIdentifier }}" id="{{ group.id }}" class="custom-select sas-product-configurator-select-input">
+            <select data-name="{{ group.id }}" data-url="{{ url('sas.frontend.variant.switch', {'productId': product.parentId ?? product.id }) }}" name="{{ groupIdentifier }}" id="{{ group.id }}" class="custom-select sas-product-configurator-select-input">
                 {% for option in group.options %}
 
                     {% set selected = false %}

--- a/src/Storefront/Page/ProductListingConfigurationLoader.php
+++ b/src/Storefront/Page/ProductListingConfigurationLoader.php
@@ -50,22 +50,22 @@ class ProductListingConfigurationLoader
         /** @var SalesChannelProductEntity $product */
         foreach ($products as $product) {
             $productSettings = $this->loadSettings(clone $settings);
+            $parentId = $product->getParentId() ?? $product->getId();
 
-            if ($product->getConfiguratorSettings() !== null || !$product->getParentId() || empty($productSettings[$product->getParentId()])) {
+            if ($product->getConfiguratorSettings() !== null || empty($productSettings[$parentId])) {
+
                 $product->addExtension('groups', new PropertyGroupCollection());
-
                 continue;
             }
 
-            $productSetting = $productSettings[$product->getParentId()];
-
+            $productSetting = $productSettings[$parentId];
             $groups = $this->sortSettings($productSetting, $product);
 
-            if (!array_key_exists($product->getParentId(), $allCombinations)) {
+            if (!array_key_exists($parentId, $allCombinations)) {
                 continue;
             }
 
-            $combinations = $allCombinations[$product->getParentId()];
+            $combinations = $allCombinations[$parentId];
 
             $current = $this->buildCurrentOptions($product, $groups);
 
@@ -330,15 +330,16 @@ class ProductListingConfigurationLoader
         $keyMap = $groups->getOptionIdMap();
 
         $current = [];
-        foreach ($product->getOptionIds() as $optionId) {
-            $groupId = $keyMap[$optionId] ?? null;
-            if ($groupId === null) {
-                continue;
+        if (null !== $optionIds = $product->getOptionIds()) {
+            foreach ($optionIds as $optionId) {
+                $groupId = $keyMap[$optionId] ?? null;
+                if ($groupId === null) {
+                    continue;
+                }
+
+                $current[$groupId] = $optionId;
             }
-
-            $current[$groupId] = $optionId;
         }
-
         return $current;
     }
 }


### PR DESCRIPTION
We wanted to use the plugin with setting the _Storefront presentation_ to _Display single product_ -> _Main product_ what currently does not work in the plugin.

Our modification will enable this.

On product level you set `Variants->Storefront presentation` to this:

![image](https://github.com/Shape-and-Shift/shopware-variant-switch/assets/537665/af177def-ac70-4f52-b4bf-141fcb076bfd)

and the result on the Category Listing will somewhat look like this:

![image](https://github.com/Shape-and-Shift/shopware-variant-switch/assets/537665/7e5e96b7-22f8-4864-9827-0fcefec02563)

