### PR TITLE
Load variant selection on search result page

### DIFF
--- a/src/Subscriber/ProductListingResultLoadedSubscriber.php
+++ b/src/Subscriber/ProductListingResultLoadedSubscriber.php
@@ -4,6 +4,7 @@ namespace SasVariantSwitch\Subscriber;
 
 use SasVariantSwitch\SasVariantSwitch;
 use Shopware\Core\Content\Product\Events\ProductListingResultEvent;
+use Shopware\Core\Content\Product\Events\ProductSearchResultEvent;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -28,6 +29,9 @@ class ProductListingResultLoadedSubscriber implements EventSubscriberInterface
         return [
             // 'sales_channel.product.loaded' => 'handleProductListingLoadedRequest',
             ProductListingResultEvent::class => [
+                ['handleProductListingLoadedRequest', 201],
+            ],
+            ProductSearchResultEvent::class => [
                 ['handleProductListingLoadedRequest', 201],
             ],
             ProductBoxLoadedEvent::class => [


### PR DESCRIPTION
The variant selection is not displayed on the search result page. This is due the missing event for the search result page.